### PR TITLE
feat: 임박 재료 페이지에서 레시피 페이지 연결

### DIFF
--- a/app/urgent/page.tsx
+++ b/app/urgent/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import BottomNav from "@/components/BottomNav";
 import { mockIngredients, type Category } from "@/data/dummydata";
 import { getDaysLeft } from "@/utils/expiryHelpers";
@@ -44,7 +45,7 @@ function formatPurchaseDate(dateString: string) {
 export default function UrgentPage() {
   const urgentItems = mockIngredients
   .map((item) => {
-    const daysLeft = getDaysLeft(item.purchaseDate, item.category);
+    const daysLeft = getDaysLeft(item.expiryDate);
     return {
       ...item,
       daysLeft,
@@ -87,7 +88,7 @@ export default function UrgentPage() {
                   <p className="shrink-0 text-base font-extrabold text-gray-950">
                     {item.quantityValue !== undefined
                       ? `${item.quantityValue}개`
-                      : item.quantity}
+                      : item.quantityStatus}
                   </p>
                   <span
                     className={`ml-auto rounded-md px-2.5 py-1 text-sm font-bold leading-none ${getDdayBadgeClass(
@@ -105,9 +106,12 @@ export default function UrgentPage() {
           ))}
         </div>
 
-        <button className="mt-10 w-full rounded-md border border-gray-300 bg-white py-3 text-base font-bold text-gray-900 shadow-sm">
+        <Link
+          href="/recipe"
+          className="mt-10 block w-full rounded-md border border-gray-300 bg-white py-3 text-center text-base font-bold text-gray-900 shadow-sm"
+        >
           활용 가능한 레시피 확인하기
-        </button>
+        </Link>
 
         <div className="h-5" />
       </div>


### PR DESCRIPTION
## 작업 내용
- 임박 재료 페이지의 "활용 가능한 레시피 확인하기" 버튼을 레시피 페이지로 연결
- 최신 ingredient 타입 구조에 맞게 urgency 페이지 로직 정리
  - getDaysLeft에 expiryDate 사용
  - quantityStatus 표시로 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved urgent item expiration calculation for more accurate time remaining.
  * Fixed quantity display fallback behavior.

* **New Features**
  * Recipe recommendation action now navigates directly to the recipe section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->