### PR TITLE
장바구니 선택 품목 냉장고 추가 연동

### DIFF
--- a/app/cart/page.tsx
+++ b/app/cart/page.tsx
@@ -4,6 +4,9 @@ import React, { useState, useRef, useEffect } from "react";
 import BottomNav from "@/components/BottomNav";
 import { ShoppingCart, Search, ArrowLeft, Plus, Minus, Refrigerator, Trash2, X } from "lucide-react";
 import { fetchMasterIngredients, createFridgeItem, type MasterIngredient } from "@/lib/fridgeApi";
+import { getUserIdFromToken } from "@/utils/auth";
+import { useToast } from "@/hooks/useToast";
+import Toast from "@/components/Toast";
 
 // ── 애니메이션 ────────────────────────────────────────────────────
 const STYLES = `
@@ -202,6 +205,7 @@ export default function CartPage() {
   const [searchKeyword, setSearchKeyword] = useState("");
   const [masterIngredients, setMasterIngredients] = useState<MasterIngredient[]>([]);
   const [addingToFridge, setAddingToFridge] = useState(false);
+  const { toastMessage, toastVisible, showToast } = useToast();
 
   const checkedItems = items.filter((i) => i.checked);
   const checkedCount = checkedItems.length;
@@ -247,6 +251,12 @@ export default function CartPage() {
 
   async function handleAddToFridge() {
     if (checkedCount === 0 || addingToFridge) return;
+    const memberId = getUserIdFromToken();
+    if (!memberId) {
+      showToast("로그인이 필요합니다");
+      return;
+    }
+
     setAddingToFridge(true);
 
     const defaultExpiry = (() => {
@@ -257,12 +267,17 @@ export default function CartPage() {
 
     const nameToIngredient = new Map(masterIngredients.map((m) => [m.name, m]));
     const succeeded: number[] = [];
+    const missing: string[] = [];
 
     await Promise.allSettled(
       checkedItems.map(async (cartItem) => {
         const master = nameToIngredient.get(cartItem.name);
-        if (!master) return;
+        if (!master) {
+          missing.push(cartItem.name);
+          return;
+        }
         await createFridgeItem({
+          memberId,
           ingredientId: master.ingredientId,
           quantity: cartItem.quantity,
           unit: "개",
@@ -274,6 +289,11 @@ export default function CartPage() {
 
     if (succeeded.length > 0) {
       setItems((prev) => prev.filter((i) => !succeeded.includes(i.id)));
+      showToast(`${succeeded.length}개 품목을 냉장고에 추가했어요`);
+    } else if (missing.length > 0) {
+      showToast("등록된 재료명만 냉장고에 추가할 수 있어요");
+    } else {
+      showToast("냉장고 추가에 실패했어요");
     }
     setAddingToFridge(false);
   }
@@ -488,13 +508,14 @@ export default function CartPage() {
               <div className="flex gap-2">
                 <button
                   onClick={handleAddToFridge}
+                  disabled={addingToFridge}
                   className="flex-1 flex items-center justify-center gap-1.5 py-3.5 rounded-2xl
                     bg-green-600 text-white text-[13px] font-bold
                     active:scale-[0.97] transition-transform duration-150
-                    shadow-[0_4px_14px_rgba(22,163,74,0.3)]"
+                    shadow-[0_4px_14px_rgba(22,163,74,0.3)] disabled:opacity-60"
                 >
                   <Refrigerator className="w-4 h-4" />
-                  냉장고에 추가
+                  {addingToFridge ? "추가 중..." : "냉장고에 추가"}
                 </button>
                 <button
                   onClick={handleDeleteChecked}
@@ -521,6 +542,7 @@ export default function CartPage() {
           </div>
 
           <BottomNav />
+          <Toast message={toastMessage} visible={toastVisible} />
         </div>
       </div>
     </>

--- a/app/fridge/page.tsx
+++ b/app/fridge/page.tsx
@@ -46,6 +46,7 @@ export default function FridgePage() {
   const [masterIngredients, setMasterIngredients] = useState<MasterIngredient[]>([]);
   const [loading, setLoading] = useState(true);
   const [authError, setAuthError] = useState(false);
+  const [memberId, setMemberId] = useState<number | null>(null);
 
   const [selectedCategory, setSelectedCategory] = useState<FilterCategory>("전체");
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -66,6 +67,7 @@ export default function FridgePage() {
         setLoading(false);
         return;
       }
+      setMemberId(memberId);
 
       const [fridgeResult, masterResult] = await Promise.allSettled([
         fetchFridgeList(memberId),
@@ -137,6 +139,10 @@ export default function FridgePage() {
     const qty = Number(form.quantity);
 
     if (modalMode === "add") {
+      if (!memberId) {
+        showToast("로그인이 필요합니다");
+        return;
+      }
       if (!form.selectedIngredientId) {
         alert("재료를 검색해서 선택해 주세요.");
         return;
@@ -144,6 +150,7 @@ export default function FridgePage() {
 
       try {
         const created = await createFridgeItem({
+          memberId,
           ingredientId: form.selectedIngredientId,
           quantity: qty,
           unit: form.unit,

--- a/lib/fridgeApi.ts
+++ b/lib/fridgeApi.ts
@@ -1,6 +1,6 @@
 import { getToken } from "@/utils/auth";
 
-const BASE_URL = "http://localhost:8080";
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080";
 
 function authHeaders(): Record<string, string> {
   const token = getToken();
@@ -61,6 +61,7 @@ export async function fetchMasterIngredients(): Promise<MasterIngredient[]> {
 }
 
 export async function createFridgeItem(data: {
+  memberId: number;
   ingredientId: number;
   quantity: number;
   unit: string;


### PR DESCRIPTION
## 관련 이슈

> #{ISSUE_NUMBER}

## 작업 내용
- 장바구니에서 선택한 품목을 냉장고 추가 API와 연결
- 냉장고 추가 요청 시 백엔드가 요구하는 `memberId` 포함
- 냉장고 페이지에서 직접 재료 추가 시에도 `memberId` 포함하도록 수정
- 장바구니에서 냉장고 이동 성공/실패 토스트 추가
- 냉장고 API URL을 환경변수 기반으로 변경

## 테스트
- 장바구니에서 품목 선택 후 냉장고 추가 동작 확인
- 추가된 품목이 냉장고 페이지에 표시되는 것 확인

## ETC
- 장바구니 자체를 DB에 저장하는 기능은 아직 구현되지 않음

