### PR TITLE
로그인 실패 및 온보딩 저장 오류 안내

### DIFF
--- a/app/auth/kakao/callback/page.tsx
+++ b/app/auth/kakao/callback/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Suspense, useEffect, useRef } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
+import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { setToken } from "@/utils/auth";
 
@@ -24,10 +25,32 @@ function LoadingScreen() {
   );
 }
 
+function LoginErrorScreen({ message }: { message: string }) {
+  return (
+    <main className="min-h-screen bg-[#f2f4f7] text-[#111111]">
+      <div className="mx-auto flex min-h-screen w-full max-w-[390px] flex-col items-center justify-center bg-white px-6 py-10 text-center">
+        <h1 className="text-2xl font-extrabold tracking-[-0.04em]">
+          로그인에 실패했어요
+        </h1>
+        <p className="mt-3 text-sm leading-6 text-[#6f7682]">
+          {message}
+        </p>
+        <Link
+          href="/login"
+          className="mt-8 w-full rounded-2xl bg-[#118d3f] px-5 py-4 text-sm font-bold text-white shadow-[0_12px_24px_rgba(17,141,63,0.18)]"
+        >
+          로그인 화면으로 돌아가기
+        </Link>
+      </div>
+    </main>
+  );
+}
+
 function KakaoCallbackContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const called = useRef(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   useEffect(() => {
     if (called.current) return;
@@ -35,12 +58,16 @@ function KakaoCallbackContent() {
 
     const code = searchParams.get("code");
     if (!code) {
-      router.replace("/login");
+      setErrorMessage("카카오 로그인 정보를 확인할 수 없어요. 다시 로그인해 주세요.");
       return;
     }
 
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 15_000);
+    let timedOut = false;
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, 15_000);
 
     (async () => {
       try {
@@ -51,7 +78,9 @@ function KakaoCallbackContent() {
           signal: controller.signal,
         });
 
-        if (!loginRes.ok) throw new Error("Login failed");
+        if (!loginRes.ok) {
+          throw new Error("카카오 인증을 완료하지 못했어요. 다시 로그인해 주세요.");
+        }
 
         const { accessToken } = (await loginRes.json()) as { accessToken: string };
 
@@ -67,7 +96,9 @@ function KakaoCallbackContent() {
           signal: controller.signal,
         });
 
-        if (!userRes.ok) throw new Error("User fetch failed");
+        if (!userRes.ok) {
+          throw new Error("사용자 정보를 불러오지 못했어요. 다시 로그인해 주세요.");
+        }
 
         const user = (await userRes.json()) as {
           categories: string[];
@@ -85,9 +116,19 @@ function KakaoCallbackContent() {
 
         router.replace(hasPreferences ? "/" : "/login/setup");
       } catch (err) {
-        if (err instanceof Error && err.name !== "AbortError") {
-          router.replace("/login");
+        if (err instanceof Error && err.name === "AbortError") {
+          if (timedOut) {
+            setErrorMessage("로그인 확인 시간이 초과되었어요. 다시 시도해 주세요.");
+          }
+          return;
         }
+        const knownMessage =
+          err instanceof Error && err.message.endsWith("다시 로그인해 주세요.");
+        setErrorMessage(
+          knownMessage
+            ? err.message
+            : "로그인 서버에 연결하지 못했어요. 잠시 후 다시 로그인해 주세요."
+        );
       } finally {
         clearTimeout(timeout);
       }
@@ -96,7 +137,7 @@ function KakaoCallbackContent() {
     return () => controller.abort();
   }, [router, searchParams]);
 
-  return <LoadingScreen />;
+  return errorMessage ? <LoginErrorScreen message={errorMessage} /> : <LoadingScreen />;
 }
 
 export default function KakaoCallbackPage() {

--- a/app/login/setup/page.tsx
+++ b/app/login/setup/page.tsx
@@ -99,6 +99,7 @@ export default function LoginSetupPage() {
   const router = useRouter();
   const [stepIndex, setStepIndex] = useState(0);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
   const [selectedCategories, setSelectedCategories] = useState<number[]>([]);
   const [selectedTastes, setSelectedTastes] = useState<number[]>([]);
   const [selectedAllergies, setSelectedAllergies] = useState<number[]>([]);
@@ -140,14 +141,19 @@ export default function LoginSetupPage() {
       return;
     }
 
+    setSubmitError(null);
     setIsSubmitting(true);
     try {
       const token = getToken();
+      if (!token) {
+        setSubmitError("로그인 정보가 없어요. 다시 로그인한 뒤 저장해 주세요.");
+        return;
+      }
       const res = await fetch(`${API_URL}/api/v1/users/onboard`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify({
           categories: selectedCategories,
@@ -156,12 +162,12 @@ export default function LoginSetupPage() {
         }),
       });
       if (!res.ok) throw new Error("Onboard failed");
+      router.push("/login/complete");
     } catch {
-      // 실패해도 완료 화면으로 진행
+      setSubmitError("선호도 저장에 실패했어요. 잠시 후 다시 시도해 주세요.");
     } finally {
       setIsSubmitting(false);
     }
-    router.push("/login/complete");
   };
 
   return (
@@ -221,6 +227,11 @@ export default function LoginSetupPage() {
           >
             {isSubmitting ? "저장 중..." : isLastStep ? "완료" : "다음"}
           </button>
+          {submitError && (
+            <p role="alert" className="text-center text-sm font-medium text-[#d45c68]">
+              {submitError}
+            </p>
+          )}
           {!isLastStep && (
             <button
               type="button"


### PR DESCRIPTION
## 관련 이슈

> 로그인 및 온보딩 백엔드 연동 실패 처리 보완

## 작업 내용

- 카카오 callback에서 인증 코드가 없을 때 오류 안내 화면 표시
- 로그인 API 요청 실패 시 다시 로그인할 수 있도록 안내 추가
- 사용자 정보 조회 실패 및 서버 연결 실패 시 오류 안내 추가
- 로그인 확인 요청이 시간초과될 때 안내 메시지 표시
- 온보딩 저장 성공 시에만 완료 화면으로 이동하도록 수정
- 온보딩 저장 실패 또는 로그인 토큰 누락 시 재시도 안내 표시

## ETC

> `npm.cmd run lint -- app/auth/kakao/callback/page.tsx app/login/setup/page.tsx` 통과
>
> 전체 `tsc` 검사는 기존 `main`의 `app/fridge/page.tsx` `memberId` 오류로 실패하며, 이번 PR 변경과는 별개입니다.