### PR TITLE
[cart] 장바구니 세부 기능 구현

### DIFF
--- a/app/cart/page.tsx
+++ b/app/cart/page.tsx
@@ -62,21 +62,9 @@ function CartItemCard({
   onQuantityChange: (id: number, newQty: number) => void;
   onDelete: (id: number) => void;
 }) {
-  const [isSwiped, setIsSwiped] = useState(false);
   const [checkAnim, setCheckAnim] = useState(false);
-  const touchStartX = useRef(0);
-
-  function handleTouchStart(e: React.TouchEvent) {
-    touchStartX.current = e.touches[0].clientX;
-  }
-  function handleTouchEnd(e: React.TouchEvent) {
-    const diff = touchStartX.current - e.changedTouches[0].clientX;
-    if (diff > 50) setIsSwiped(true);
-    if (diff < -30) setIsSwiped(false);
-  }
 
   function handleToggle() {
-    if (isSwiped) { setIsSwiped(false); return; }
     setCheckAnim(true);
     onToggle(item.cartItemId, !item.isChecked);
     setTimeout(() => setCheckAnim(false), 350);
@@ -84,30 +72,16 @@ function CartItemCard({
 
   return (
     <div
-      className="relative overflow-hidden rounded-2xl anim-item-in"
+      className="relative rounded-2xl anim-item-in"
       style={{ animationDelay: `${index * 45}ms` }}
     >
-      <div className="absolute right-0 top-0 h-full w-20 bg-gradient-to-l from-red-500 to-rose-400 rounded-r-2xl flex flex-col items-center justify-center gap-1">
-        <button
-          onClick={() => onDelete(item.cartItemId)}
-          className="flex flex-col items-center gap-1 text-white"
-          aria-label="삭제"
-        >
-          <Trash2 className="w-5 h-5" />
-          <span className="text-[10px] font-bold">삭제</span>
-        </button>
-      </div>
-
       <div
         className={`relative flex items-center gap-3 px-4 py-3.5 rounded-2xl border transition-all duration-200
           ${item.isChecked
             ? "bg-gray-50 border-gray-100"
             : "bg-white border-gray-100 shadow-[0_2px_12px_rgba(0,0,0,0.06)]"
           }
-          ${isSwiped ? "-translate-x-20" : "translate-x-0"}
         `}
-        onTouchStart={handleTouchStart}
-        onTouchEnd={handleTouchEnd}
         onClick={handleToggle}
       >
         <div

--- a/app/cart/page.tsx
+++ b/app/cart/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import BottomNav from "@/components/BottomNav";
 import { ShoppingCart, Search, ArrowLeft, Plus, Minus, Refrigerator, Trash2, X } from "lucide-react";
 import {
@@ -54,13 +54,11 @@ function CartItemCard({
   index,
   onToggle,
   onQuantityChange,
-  onDelete,
 }: {
   item: CartItem;
   index: number;
   onToggle: (id: number, checked: boolean) => void;
   onQuantityChange: (id: number, newQty: number) => void;
-  onDelete: (id: number) => void;
 }) {
   const [checkAnim, setCheckAnim] = useState(false);
 
@@ -511,7 +509,6 @@ export default function CartPage() {
                         index={i}
                         onToggle={handleToggle}
                         onQuantityChange={handleQuantityChange}
-                        onDelete={handleDelete}
                       />
                     ))}
                   </div>

--- a/app/fridge/page.tsx
+++ b/app/fridge/page.tsx
@@ -355,7 +355,6 @@ export default function FridgePage() {
                 isSelected={selectedIds.includes(item.fridgeId)}
                 onSelect={handleSelect}
                 onLongPress={handleLongPress}
-                onDelete={handleDelete}
                 onEditPress={handleOpenEdit}
               />
             ))

--- a/app/recipe/[id]/page.tsx
+++ b/app/recipe/[id]/page.tsx
@@ -85,12 +85,16 @@ export default function RecipeDetailPage() {
 
   async function handleCartConfirm(selected: RecipeIngredient[]) {
     await addCartItems(
-      selected.map((ing) => ({
-        ingredientId: ing.ingredientId,
-        name: ing.name,
-        quantity: 1,
-        unit: ing.unit || null,
-      }))
+      selected.map((ing) => {
+        const parsed = Math.round(parseFloat(ing.amount));
+        const quantity = isNaN(parsed) || parsed < 1 ? 1 : parsed;
+        return {
+          ingredientId: ing.ingredientId,
+          name: ing.name,
+          quantity,
+          unit: ing.unit || null,
+        };
+      })
     );
     showToast(`${selected.length}개 재료를 장바구니에 담았어요`);
   }

--- a/components/fridge/FridgeItemCard.tsx
+++ b/components/fridge/FridgeItemCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useRef } from "react";
 import { FridgeItem } from "@/lib/fridgeApi";
 import { getDaysLeft } from "@/utils/expiryHelpers";
 
@@ -56,8 +56,6 @@ export default function FridgeItemCard({
   onEditPress,
   onDelete,
 }: FridgeItemCardProps) {
-  const [isSwiped, setIsSwiped] = useState(false);
-  const touchStartX = useRef<number>(0);
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const daysLeft = getDaysLeft(item.expiryDate);
@@ -65,18 +63,14 @@ export default function FridgeItemCard({
   const qLevel   = getQuantityLevel(item.quantity, item.unit);
   const qColor   = QUANTITY_COLOR[qLevel];
 
-  function handleTouchStart(e: React.TouchEvent) {
-    touchStartX.current = e.touches[0].clientX;
+  function handleTouchStart() {
     longPressTimer.current = setTimeout(() => {
       if (!isSelectMode) onLongPress(item.fridgeId);
     }, 500);
   }
 
-  function handleTouchEnd(e: React.TouchEvent) {
+  function handleTouchEnd() {
     if (longPressTimer.current) { clearTimeout(longPressTimer.current); longPressTimer.current = null; }
-    const diff = touchStartX.current - e.changedTouches[0].clientX;
-    if (diff > 60)  setIsSwiped(true);
-    if (diff < -30) setIsSwiped(false);
   }
 
   function handleTouchMove() {
@@ -84,31 +78,12 @@ export default function FridgeItemCard({
   }
 
   function handleCardTap() {
-    if (isSwiped) { setIsSwiped(false); return; }
     if (isSelectMode) onSelect(item.fridgeId);
     else onEditPress(item);
   }
 
-  function handleDeleteRequest() {
-    const confirmed = window.confirm(`"${item.ingredientName}"을(를) 삭제할까요?`);
-    if (confirmed) onDelete(item.fridgeId);
-    setIsSwiped(false);
-  }
-
   return (
-    <div className="relative overflow-hidden rounded-2xl">
-
-      {/* 스와이프 삭제 버튼 */}
-      <div className="absolute right-0 top-0 h-full w-20 bg-gradient-to-l from-red-500 to-rose-400 rounded-r-2xl flex flex-col items-center justify-center gap-1">
-        <button onClick={handleDeleteRequest} aria-label="재료 삭제" className="flex flex-col items-center gap-1 text-white">
-          <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5" fill="none"
-            viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-            <path strokeLinecap="round" strokeLinejoin="round"
-              d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-          </svg>
-          <span className="text-[10px] font-bold">삭제</span>
-        </button>
-      </div>
+    <div className="relative rounded-2xl">
 
       {/* 카드 본체 */}
       <div
@@ -117,7 +92,6 @@ export default function FridgeItemCard({
             ? "border-2 border-green-500 shadow-[0_0_0_3px_rgba(34,197,94,0.12)]"
             : "border border-gray-100 shadow-[0_2px_12px_rgba(0,0,0,0.06)]"
           }
-          ${isSwiped ? "-translate-x-20" : "translate-x-0"}
         `}
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}

--- a/components/fridge/FridgeItemCard.tsx
+++ b/components/fridge/FridgeItemCard.tsx
@@ -11,7 +11,6 @@ type FridgeItemCardProps = {
   onLongPress: (fridgeId: number) => void;
   onSelect: (fridgeId: number) => void;
   onEditPress: (item: FridgeItem) => void;
-  onDelete: (fridgeId: number) => void;
 };
 
 function formatKoreanDate(dateStr: string) {
@@ -54,7 +53,6 @@ export default function FridgeItemCard({
   onLongPress,
   onSelect,
   onEditPress,
-  onDelete,
 }: FridgeItemCardProps) {
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 


### PR DESCRIPTION
## 관련 이슈

> #47 

## 작업 내용
- 장바구니 재료 선택 오류 개선
- 상세 레시피 페이지에서 재료 장바구니 추가시 수량 파싱 되도록 구현

## ETC
> 참고할만한 링크 또는 메모



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recipe ingredients added to cart now automatically calculate quantities based on ingredient amounts.

* **Refactor**
  * Removed swipe gesture support for deleting items from cart and fridge lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->